### PR TITLE
fix the typo in the entrypoint for rest_api docker container

### DIFF
--- a/docker/compose/sawtooth-default.yaml
+++ b/docker/compose/sawtooth-default.yaml
@@ -73,7 +73,7 @@ services:
       - "8080:8080"
     depends_on:
       - validator
-    entrypoint: rest_api --connect tcp://validator:4004 -bind rest_api:8080
+    entrypoint: rest_api --connect tcp://validator:4004 --bind rest_api:8080
 
   client:
     image: hyperledger/sawtooth-all:latest


### PR DESCRIPTION
in the entrypoint for rest_api there is - missing for bind. It should be --bind and not -bind